### PR TITLE
Multiple countries resources

### DIFF
--- a/client/src/components/App.js
+++ b/client/src/components/App.js
@@ -78,7 +78,7 @@ export default class App extends React.Component {
     if (this.state.messages.length > 0) {
       if (this.state.messages[this.state.messages.length - 1].speech === '') {
         this.setState(prevState => ({
-          messages: [...prevState.messages.slice(0, -1)]
+          messages: [...prevState.messages.slice(0, -1)],
         }));
       }
     }

--- a/client/src/components/message/Message.js
+++ b/client/src/components/message/Message.js
@@ -88,6 +88,9 @@ const Message = (props) => {
 
       <SelectOptions
         selectOptions={messageObj.selectOptions}
+        addMessage={addMessage}
+        sendMessage={sendMessage}
+        uniqueId={uniqueId}
       />
 
     </div>

--- a/client/src/components/select-buttons/SelectOptions.js
+++ b/client/src/components/select-buttons/SelectOptions.js
@@ -10,7 +10,7 @@ const SelectOptionsDiv = styled.div`
 
 const CountryOptionDiv = styled.div`
   border: 2px #b0b0b0 solid;
-  color: #b0b0b0;
+  color: black;
   background: white;
   margin-bottom: 20px;
   margin-right: 5px;
@@ -50,7 +50,7 @@ const SubmitButton = styled.button.attrs({
 
   &:disabled {
     background: white;
-    color: #b0b0b0;
+    color: black;
     cursor: not-allowed;
   }
 `;
@@ -82,27 +82,55 @@ export default class SelectOptions extends Component {
 
       return { activeOptions: newActiveOptions };
     });
-  }
+  };
 
-  renderSelectOptions = () => this.props.selectOptions.map((selectOption, index) => (
-    <CountryOptionDiv
-      key={selectOption.text}
-      active={this.state.activeOptions[index] ? 'active' : ''}
-      onClick={() => this.countryOptionClickHandler(selectOption, index)}
-    >
-      {selectOption.text}
-    </CountryOptionDiv>
-  ));
+  submitHandler = () => {
+    const selectedCountries = this.state.activeOptions
+      .map((option, index) => (option ? this.props.selectOptions[index] : null))
+      .filter(Boolean);
+
+    selectedCountries.forEach((countryObj) => {
+      const data = {
+        isUser: true,
+        isWaiting: true,
+        speech: countryObj.text,
+        uniqueId: this.props.uniqueId,
+      };
+
+      this.props.addMessage(data);
+    });
+
+    this.props.sendMessage({
+      speech: selectedCountries[0].postback,
+      uniqueId: this.props.uniqueId,
+      selectedCountries,
+    });
+
+    this.setState({ disabled: true });
+  };
+
+  renderSelectOptions = () =>
+    this.props.selectOptions.map((selectOption, index) => (
+      <CountryOptionDiv
+        key={selectOption.text}
+        active={this.state.activeOptions[index] ? 'active' : ''}
+        onClick={() => this.countryOptionClickHandler(selectOption, index)}
+      >
+        {selectOption.text}
+      </CountryOptionDiv>
+    ));
 
   render() {
-    if (this.props.selectOptions.length < 1) return null;
+    if (this.props.selectOptions.length === 0 || this.state.disabled) return null;
 
     const optionSelectedBool = this.state.activeOptions.some(Boolean);
 
     return (
       <div>
         <SelectOptionsDiv>{this.renderSelectOptions()}</SelectOptionsDiv>
-        <SubmitButton disabled={optionSelectedBool ? '' : 'disabled'}>Submit</SubmitButton>
+        <SubmitButton disabled={optionSelectedBool ? '' : 'disabled'} onClick={this.submitHandler}>
+          Submit
+        </SubmitButton>
       </div>
     );
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -484,6 +484,11 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
       "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU="
     },
+    "bluebird": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+    },
     "body-parser": {
       "version": "1.18.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
@@ -4457,6 +4462,25 @@
         "uuid": "3.2.1"
       }
     },
+    "request-promise": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.2.tgz",
+      "integrity": "sha1-0epG1lSm7k+O5qT+oQGMIpEZBLQ=",
+      "requires": {
+        "bluebird": "3.5.1",
+        "request-promise-core": "1.1.1",
+        "stealthy-require": "1.1.1",
+        "tough-cookie": "2.3.3"
+      }
+    },
+    "request-promise-core": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
+      "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+      "requires": {
+        "lodash": "4.17.5"
+      }
+    },
     "require-uncached": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
@@ -4963,6 +4987,11 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
       "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
+    },
+    "stealthy-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
     "stream-combiner": {
       "version": "0.0.4",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "nodemon": "^1.14.12",
     "pg-promise": "^7.4.1",
     "request": "^2.83.0",
+    "request-promise": "^4.2.2",
     "uuid": "^3.2.1"
   },
   "devDependencies": {

--- a/src/googleSheetRef.js
+++ b/src/googleSheetRef.js
@@ -1,0 +1,9 @@
+const gSheetLookup = {
+  DivorceIndia: 'A2:B',
+  DivorcePakistan: 'C2:D',
+  DivorceItaly: 'E2:F',
+  DivorceUK: 'G2:H',
+  Global: 'I2:J',
+};
+
+module.exports = gSheetLookup;

--- a/src/userMessage.js
+++ b/src/userMessage.js
@@ -7,23 +7,6 @@ const gSheetLookup = require('./googleSheetRef');
 
 const app = apiai(DF_KEY);
 
-// const getAndSendGSheetResources = url =>
-//   request(url)
-//     .then((body) => {
-//       const resourceArray = JSON.parse(body).values.map((resource) => {
-//         const singleResourceArray = resource.map((str, index, array) => {
-//           if (index % 2 === 1) return null;
-//           return { text: array[index], href: array[index + 1] };
-//         });
-//
-//         return singleResourceArray.filter(Boolean);
-//       });
-//       return [].concat(...resourceArray);
-//     })
-//     .catch((err) => {
-//       console.log(err);
-//     });
-
 const getResource = (countryObj) => {
   const cellRef = gSheetLookup[countryObj.lookup];
   const url = GOOGLE_API_1 + cellRef + GOOGLE_API_2;
@@ -43,13 +26,6 @@ const getResource = (countryObj) => {
     .catch((err) => {
       console.log(err);
     });
-};
-
-const findCellRef = (selectedCountries) => {
-  const { start } = gSheetLookup[selectedCountries[0].text];
-  const { end } = gSheetLookup[selectedCountries[selectedCountries.length - 1].text];
-
-  return `${start}:${end}`;
 };
 
 const apiaiCall = (req, res, speech) => {

--- a/src/userMessage.js
+++ b/src/userMessage.js
@@ -6,20 +6,59 @@ const saveMessage = require('./database/queries/save_message');
 
 const app = apiai(DF_KEY);
 
+const gSheetLookup = {
+  India: {
+    start: 'A2',
+    end: 'B',
+  },
+  Pakistan: {
+    start: 'C2',
+    end: 'D',
+  },
+  Italy: {
+    start: 'E2',
+    end: 'F',
+  },
+  UK: {
+    start: 'G2',
+    end: 'H',
+  },
+  Global: {
+    start: 'I2',
+    end: 'J',
+  },
+};
+
+const getAndSendGSheetResources = (res, data, url) => {
+  const newData = Object.assign({}, data);
+  request(url, (err, gsres, body) => {
+    const resourceArray = JSON.parse(body).values.map((resource) => {
+      const singleResourceArray = resource.map((str, index, array) => {
+        if (index % 2 === 1) return null;
+        return { text: array[index], href: array[index + 1] };
+      });
+
+      return singleResourceArray.filter(Boolean);
+    });
+    newData.resources = [].concat(...resourceArray);
+    res.send(newData);
+  });
+};
+
+const findCellRef = (selectedCountries) => {
+  const { start } = gSheetLookup[selectedCountries[0].text];
+  const { end } = gSheetLookup[selectedCountries[selectedCountries.length - 1].text];
+
+  return `${start}:${end}`;
+};
+
 const apiaiCall = (req, res, speech) => {
   saveMessage(speech, req.body.uniqueId);
   const requestdf = app.textRequest(speech, {
-    sessionId: req.body.uniqueId
+    sessionId: req.body.uniqueId,
   });
 
   requestdf.on('response', (response) => {
-    const lookup = {
-      DivorceIndia: 'A2:B',
-      DivorcePakistan: 'C2:D',
-      DivorceItaly: 'E2:F',
-      DivorceUK: 'G2:H',
-      DivorceGlobal: 'I2:J'
-    };
     const { messages } = response.result.fulfillment;
     const data = {
       speech: messages[0].speech,
@@ -27,33 +66,25 @@ const apiaiCall = (req, res, speech) => {
       resources: [],
       selectOptions: [],
       retrigger: '',
-      timedelay: ''
+      timedelay: '',
     };
 
     saveMessage(data.speech, response.sessionId);
 
     const payload = messages[1] ? messages[1].payload : {};
-    if (!payload.timedelay) {
-      data.timedelay = 'fast';
-    } else {
-      data.timedelay = payload.timedelay;
-    }
+
+    data.timedelay = payload.timedelay ? payload.timedelay : 'fast';
 
     if (payload.retrigger) {
       data.retrigger = payload.retrigger;
     }
 
     if (payload.resources) {
-      const cellRef = lookup[payload.resources];
+      let { selectedCountries } = req.body;
+      selectedCountries = selectedCountries || [{ text: 'Global' }];
+      const cellRef = findCellRef(selectedCountries);
       const url = GOOGLE_API_1 + cellRef + GOOGLE_API_2;
-      request(url, (err, gsres, body) => {
-        const resourceArray = JSON.parse(body).values.map(resource => ({
-          text: resource[0],
-          href: resource[1],
-        }));
-        data.resources = [...resourceArray];
-        res.send(data);
-      });
+      getAndSendGSheetResources(res, data, url);
     } else {
       data.options = payload.options ? [...payload.options] : data.options;
       data.selectOptions = payload.selectOptions ? [...payload.selectOptions] : data.selectOptions;


### PR DESCRIPTION
In this PR
- submit multiple countries from front end
- 'None of the above' takes you down 'suggest a country' route
- Send selected countries to server
- If DF says `payload.resources === true`, we pull off `selectedCountries` from `res`   
- If no `selectedCountries` it will get global resources
- For each selected country, do a request to google sheet to get resource info
- Send all resources back to FE
- If error during this, send error message
 
closes #96 🎉🎉🎉 