### PR TITLE
fix kitty squish bug in Safari

### DIFF
--- a/client/src/components/buttons/Button.js
+++ b/client/src/components/buttons/Button.js
@@ -12,6 +12,7 @@ const Botbuttons = styled.div`
 const Styledbutton = styled.button`
   border: 2px #b0b0b0 solid;
   color: black;
+  background: white;
   margin: 5%;
   border-radius: 15px;
   font-size: 1rem;
@@ -24,6 +25,7 @@ const Styledbutton = styled.button`
 const Countrybutton = styled.button`
   border: 2px #b0b0b0 solid;
   color: black;
+  background: white;
   margin: 1%;
   border-radius: 15px;
   font-size: 1rem;

--- a/client/src/components/message/Message.js
+++ b/client/src/components/message/Message.js
@@ -45,8 +45,8 @@ const Usermessage = styled.p`
 `;
 
 const StyledImg = styled.img`
-  width: 50px;
-  height: 50px;
+  width: 10%;
+  height: 10%;
   margin-top: 1rem;
   margin-left: 2%;
 `;

--- a/client/src/components/message/Message.js
+++ b/client/src/components/message/Message.js
@@ -19,6 +19,7 @@ const Botmessage = styled.p`
   border-radius: 15px;
   padding: 10px;
   min-width: 2.2rem;
+  max-width: 60%;
 
   ${props =>
     props.dotty &&
@@ -44,8 +45,8 @@ const Usermessage = styled.p`
 `;
 
 const StyledImg = styled.img`
-  width: 12%;
-  height: 12%;
+  width: 50px;
+  height: 50px;
   margin-top: 1rem;
   margin-left: 2%;
 `;


### PR DESCRIPTION
In this PR:
- Fixed squished kitty img (Safari only) with fixed width/height value (`50px`) and setting a `max-width: 60%` for `Botmessage div`
- Make buttons have white background across all browsers

relates to #99 