### PR TITLE
set NODE_ENV to test when running test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "node ./src/server.js",
     "start:test": "NODE_ENV=production node ./src/server.js",
     "postinstall": "cd client && npm install && npm run build",
-    "test": "tape ./src/test/test.js | tap-spec",
+    "test": "NODE_ENV=test tape ./src/test/test.js | tap-spec",
     "server": "nodemon ./src/server.js",
     "dev": "concurrently \"npm run server\" \"npm run client\"",
     "client": "cd client && npm start"


### PR DESCRIPTION
Set the node enviroment to `test` when running tests, so it actually uses test DB 🙈 

closes #66  